### PR TITLE
記事の公開日時に未来の時刻を指定しない

### DIFF
--- a/content/post/2017-11-06__hg__people-who-work-hard-unnaturally.md
+++ b/content/post/2017-11-06__hg__people-who-work-hard-unnaturally.md
@@ -1,5 +1,5 @@
 +++
-date = "2017-11-06T23:30:00+09:00"
+date = "2017-11-06T23:20:00+09:00"
 description = "無理してがんばっている人へ。一息ついてあたりを見渡してみませんか。"
 draft = false
 slug = "people-who-work-hard-unnaturally"


### PR DESCRIPTION
Hugo の新しいバージョン、未来の時刻だと記事が無視されるっぽい？