### PR TITLE
新記事の雛形ファイルや必要なディレクトリを生成するスクリプトを用意する

### DIFF
--- a/scripts/new-post.rb
+++ b/scripts/new-post.rb
@@ -1,0 +1,26 @@
+require 'date'
+require 'fileutils'
+
+slug = ARGV[0]
+time = Time.now
+date = time.to_date
+
+file_path = "content/post/#{date}__hg__#{slug}.md"
+image_dir = "post/#{date.strftime('%Y/%m/%d')}"
+image_path = "#{image_dir}/#{slug}.jpg"
+
+metadata = <<~METADATA
+  +++
+  date = "#{date}T#{time.hour}:00:00+09:00"
+  title = ""
+  description = ""
+  slug = "#{slug}"
+  og_image = "#{image_path}"
+  draft = false
+  +++
+
+  <img src="/#{image_path}">
+METADATA
+
+File.write(file_path, metadata)
+FileUtils.mkdir_p(image_dir) unless Dir.exist?(image_dir)


### PR DESCRIPTION
雑なエッセイとかシュッと書いて公開するとき、記事作成のオーバーヘッドが大きいな〜と思うようになってきたので、加速するためのスクリプトを用意します。

```
$ ruby scripts/new-post.rb rough-essay
```

ってやったら

```
$ cat content/post/2018-01-13__hg__rough-essay.md
+++
date = "2018-01-13T2:00:00+09:00"
title = ""
description = ""
slug = "rough-essay"
og_image = "post/2018/01/13/rough-essay.jpg"
draft = false
+++

<img src="/post/2018/01/13/rough-essay.jpg">
```

こういうファイルが生成される。ます。
