### PR TITLE
RSS フィードに含める記事数の上限を設定する

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ languageCode = "ja-jp"
 title = "#june29jp"
 baseURL = "https://june29.jp/"
 theme = "hugo29"
+rssLimit = 20
 
 [permalinks]
   post = "/:year/:month/:day/:slug/"


### PR DESCRIPTION
なんにも考えていなかったんですが、見てみたら記事全件入りの index.xml が生成されていて「でかい！！！」となりました。

<a href="https://gohugo.io/getting-started/configuration/" title="Configure Hugo | Hugo">Configure Hugo</a> を読んでみると `rssLimit` という設定項目があるとわかりました。適当に 20 件としてみます。
